### PR TITLE
Mask clump #24, Discovered bug in #26

### DIFF
--- a/eniric/Qcalculator.py
+++ b/eniric/Qcalculator.py
@@ -173,6 +173,40 @@ def RVprec_calc_masked(wavelength, flux, mask):
     return rv_value
 
 
+def mask_clumping(wave, flux, mask):
+    """ Clump contiguous wavelength and flux sections into list.
+
+    Note: Our value of mask (0 = bad points) is opposite to usage in
+    np.ma.masked_array (1 = bad)
+    Separate function to enable through testing.
+
+    Parameters
+    ----------
+    wave: array-like of floats
+        The wavelength array to clump.
+    flux: array-like of floats
+        The glux array to clump.
+    mask: array-like of bool
+        Boolean array with True indicating the values to use/keep.
+
+    Returns
+    -------
+    wave_clumps: list(array)
+        List of the valid wavelength sections.
+    flux_clumps: list(array)
+       List of the valid flux sections.
+
+    """
+    # Turn into masked array to use clump_unmasked method.
+    mask = np.asarray(mask, dtype=bool)  # Make it bool so ~ works correctly
+
+    masked_wave = np.ma.masked_array(wave, mask=~mask)   # ma mask is inverted
+    masked_flux = np.ma.masked_array(flux, mask=~mask)   # ma mask is inverted
+
+    wave_clumps = [wave[s] for s in np.ma.clump_unmasked(masked_wave)]
+    flux_clumps = [flux[s] for s in np.ma.clump_unmasked(masked_flux)]
+
+    return wave_clumps, flux_clumps
 ###############################################################################
 def RV_prec_calc_Trans(wavelength, flux, transmission):
     """ The same as RV_prec_calc, but considering a transmission different than zero

--- a/eniric/Qcalculator.py
+++ b/eniric/Qcalculator.py
@@ -164,17 +164,16 @@ def RVprec_calc_masked(wavelength, flux, mask):
         if mask[0] is False:  # First value of mask is False was a bug in original code
             print(("{0:s}\nWarning\nA condition that would have given bad "
                    "precision the by broken clumping function was found.\nNeed "
-                   "to pinpoint this result!\n{0:s}\n").format("#"*40))
-    # numpy masked arrays consider 1 to be masked and zero to be unmasked. We want the 1s hence clump masked.
-    wavelength_clumps = [wavelength[s] for s in np.ma.clump_masked(mask)]
-    flux_clumps = [wavelength[s] for s in np.ma.clump_masked(mask)]
+                   "to find the model parameters for this!\n{0:s}\n").format("#"*40))
+        # Turn wavelength and flux into masked arrays
+        wavelength_clumps, flux_clumps = mask_clumping(wavelength, flux, mask)
 
-    # Turn ndarray into quantity array.
-    slice_rvs = Quantity(np.empty(len(wavelength), dtype=float), unit=u.meter/u.second)  # Radial velocity of each slice
-
-    for i, (wav_slice, flux_slice) in enumerate(zip(wavelength, flux)):
-        wav_slice = np.array(wav_slice)
-        flux_slice = np.array(flux_slice)
+    else:
+        # When given a already clumped solution and no mask given.
+        assert isinstance(wavelength, list)
+        assert isinstance(flux, list)
+        wavelength_clumps = wavelength
+        flux_clumps = flux
 
         slice_rvs[i] = RVprec_calc(wav_slice, flux_slice)
 

--- a/eniric/Qcalculator.py
+++ b/eniric/Qcalculator.py
@@ -207,6 +207,38 @@ def mask_clumping(wave, flux, mask):
     flux_clumps = [flux[s] for s in np.ma.clump_unmasked(masked_flux)]
 
     return wave_clumps, flux_clumps
+
+
+def bug_fixed_clumping_method(wav, flux, mask):
+    """ Old clumping method that is difficult to understand ...[0]+1)[::2].
+
+    There was a signifcant bug which was fixed.
+    The returned values were dependant on the first value in the mask. """
+    if mask[0] == 1:
+        wav_chunks_unformated = np.array_split(wav, np.where(np.diff(mask))[0]+1)[::2]
+        flux_chunks_unformated = np.array_split(flux, np.where(np.diff(mask))[0]+1)[::2]
+    else:
+        wav_chunks_unformated = np.array_split(wav, np.where(np.diff(mask))[0]+1)[1::2]
+        flux_chunks_unformated = np.array_split(flux, np.where(np.diff(mask))[0]+1)[1::2]
+
+    wav_chunks = [list(chunk) for chunk in wav_chunks_unformated]
+    flux_chunks = [list(chunk) for chunk in flux_chunks_unformated]
+
+    return wav_chunks, flux_chunks
+
+
+def bugged_clumping_method(wav, flux, mask):
+    """ Old clumping method that is difficult to understand ...[0]+1)[::2].
+    There was a signifcant bug in which the returned values depend on the first value in mask."""
+    wav_chunks_unformated = np.array_split(wav, np.where(np.diff(mask))[0]+1)[::2]
+    wav_chunks = [list(chunk) for chunk in wav_chunks_unformated]
+
+    flux_chunks_unformated = np.array_split(flux, np.where(np.diff(mask))[0]+1)[::2]
+    flux_chunks = [list(chunk) for chunk in flux_chunks_unformated]
+
+    return wav_chunks, flux_chunks
+
+
 ###############################################################################
 def RV_prec_calc_Trans(wavelength, flux, transmission):
     """ The same as RV_prec_calc, but considering a transmission different than zero

--- a/eniric/Qcalculator.py
+++ b/eniric/Qcalculator.py
@@ -108,9 +108,9 @@ def SqrtSumWis(wavelength, flux):
                           flux[:-1]))
 
 
-def RVprec_calc_chunks(wavelength, flux):
+def RVprec_calc_masked(wavelength, flux, mask):
     """ The same as RVprec_calc, but now wavelength and flux are organized into
-    chunks and the weighted average formula is used
+    chunks according to the mask and the weighted average formula is used to calculate the combined precision.
 
     When considering the average RV as delivered by several slices of a
     spectrum, the error on the average is given by the error on a weighted
@@ -119,16 +119,28 @@ def RVprec_calc_chunks(wavelength, flux):
 
     Parameters
     ----------
-    wavelength: list(array-like)
+    wavelength: array-like
         Wavelength values of chunks.
-    flux: list(array-like)
+    flux: array-like
         Flux values of the chunks.
+    mask: array-like of bool
+        Mask of transmission cuts. Zero values are excluded and used to cut up spectrum.
+
     Returns
     -------
     RV_value: float
         Weighted average RV value of spectral chunks.
 
+
+    Notes
+    -----
+    A "clump" is defined as a contiguous region of the array.
+    Solution for clumping comes from https://stackoverflow.com/questions/14605734/numpy-split-1d-array-of-chunks-separated-by-nans-into-a-list-of-the-chunks
+
     """
+    # numpy masked arrays consider 1 to be masked and zero to be unmasked. We want the 1s hence clump masked.
+    wavelength_clumps = [wavelength[s] for s in np.ma.clump_masked(mask)]
+    flux_clumps = [wavelength[s] for s in np.ma.clump_masked(mask)]
 
     RV_vector = np.array([RVprec_calc(wav_chunk, flux_chunk) for wav_chunk,
                           flux_chunk in zip(wavelength, flux)])

--- a/eniric/Qcalculator.py
+++ b/eniric/Qcalculator.py
@@ -160,6 +160,11 @@ def RVprec_calc_masked(wavelength, flux, mask):
     A test for the failing condition is added so that if ever encountered we
     can investigate the effect on he previously published results.
     """
+    if mask is not None:
+        if mask[0] is False:  # First value of mask is False was a bug in original code
+            print(("{0:s}\nWarning\nA condition that would have given bad "
+                   "precision the by broken clumping function was found.\nNeed "
+                   "to pinpoint this result!\n{0:s}\n").format("#"*40))
     # numpy masked arrays consider 1 to be masked and zero to be unmasked. We want the 1s hence clump masked.
     wavelength_clumps = [wavelength[s] for s in np.ma.clump_masked(mask)]
     flux_clumps = [wavelength[s] for s in np.ma.clump_masked(mask)]
@@ -219,6 +224,11 @@ def bug_fixed_clumping_method(wav, flux, mask):
 
     There was a signifcant bug which was fixed.
     The returned values were dependant on the first value in the mask. """
+    if mask[0] is False:  # First value of mask is False was a bug in original code
+        print(("{0:s}\nWarning\nA condition that would have given bad "
+               "precision the by broken clumping function was found.\nNeed "
+               "to find the model parameters for this!\n{0:s}\n").format("#"*40))
+
     if mask[0] == 1:
         wav_chunks_unformated = np.array_split(wav, np.where(np.diff(mask))[0]+1)[::2]
         flux_chunks_unformated = np.array_split(flux, np.where(np.diff(mask))[0]+1)[::2]

--- a/eniric/Qcalculator.py
+++ b/eniric/Qcalculator.py
@@ -136,11 +136,11 @@ def RVprec_calc_masked(wavelength, flux, mask):
 
     Parameters
     ----------
-    wavelength: array-like
+    wavelength: array-like or list(array-like)
         Wavelength values of chunks.
-    flux: array-like
+    flux: array-like or list(array-like)
         Flux values of the chunks.
-    mask: array-like of bool
+    mask: array-like of bool or None
         Mask of transmission cuts. Zero values are excluded and used to cut up spectrum.
 
     Returns
@@ -152,8 +152,13 @@ def RVprec_calc_masked(wavelength, flux, mask):
     Notes
     -----
     A "clump" is defined as a contiguous region of the array.
-    Solution for clumping comes from https://stackoverflow.com/questions/14605734/numpy-split-1d-array-of-chunks-separated-by-nans-into-a-list-of-the-chunks
+    Solution for clumping comes from
+    https://stackoverflow.com/questions/14605734/numpy-split-1d-array-of-chunks-separated-by-nans-into-a-list-of-the-chunks
 
+    There was a bug in the original clumping code which ment that chose the
+    clump depending on the first element of mask.
+    A test for the failing condition is added so that if ever encountered we
+    can investigate the effect on he previously published results.
     """
     # numpy masked arrays consider 1 to be masked and zero to be unmasked. We want the 1s hence clump masked.
     wavelength_clumps = [wavelength[s] for s in np.ma.clump_masked(mask)]

--- a/tests/test_Qcaclulator.py
+++ b/tests/test_Qcaclulator.py
@@ -13,7 +13,7 @@ import astropy.constants as const
 
 def test_RVprec_calc():
     """ Test that RVprec_calc can hande inputs as Quantities or unitless and returns a Quantity."""
-    wav = np.arange(100)
+    wav = np.arange(1, 101)
     flux = np.random.random(100)
 
     rv = Q.RVprec_calc(wav, flux)
@@ -48,7 +48,7 @@ def test_RVprec_calc_with_lists():
 def test_SqrtSumWis():
     """ Test that SqrtSumWis can hande inputs as Quantities or unitless
     and returns a dimensionless unscaled Quantity. """
-    wav = np.arange(100)
+    wav = np.arange(1, 101)
     flux = np.random.random(100)
 
     sqrtsumwis = Q.SqrtSumWis(wav, flux)
@@ -69,7 +69,7 @@ def test_SqrtSumWis():
 def test_RV_prec_calc_Trans():
 
     """ Trans should not have units """
-    wav = np.arange(100)
+    wav = np.arange(1, 101)
     flux = np.random.random(100)
     trans = np.random.random(100)
 
@@ -97,7 +97,7 @@ def test_RV_prec_calc_Trans():
 
 def test_SQRTSumWisTrans():
     """ Test squareroot sum of weights when incuding change of variance due to atmospheric transmission."""
-    wav = np.arange(100)
+    wav = np.arange(1, 101)
     flux = np.random.random(100)
     trans = np.random.random(100)
 
@@ -129,11 +129,143 @@ def test_SQRTSumWisTrans():
 
 def test_transmission_reduces_precision():
     """Check that a transmission vector reduces precision calcualtion."""
-    wav = np.arange(100)
+    wav = np.arange(100.)
     flux = np.random.random(100)
     transmission = np.random.random(100)
+
     # Value should be less then normal if trans <=1
     assert Q.RVprec_calc(wav, flux) < Q.RV_prec_calc_Trans(wav, flux, transmission)
-
     # Unitary transmission should give equivalent result.
     assert Q.RVprec_calc(wav, flux) == Q.RV_prec_calc_Trans(wav, flux, np.ones_like(wav))
+
+
+def test_RV_prec_masked():
+    """ Test same prections results between past pre-clumped version and mask version
+    """
+    wav = np.arange(100)
+    flux = np.random.random(100) * 10
+    mask = np.asarray(np.floor(2*np.random.random(100)), dtype=bool)
+
+    # Pre clumping as in nIR_precion.py
+    wav_chunks, flux_chunks = Q.bug_fixed_clumping_method(wav, flux, mask)
+    rv_chunks = Q.RVprec_calc_masked(wav_chunks, flux_chunks, mask=None)
+
+    rv_masked = Q.RVprec_calc_masked(wav, flux, mask)
+
+    assert rv_masked.value == rv_chunks.value
+    assert isinstance(rv_masked, u.Quantity)
+    assert rv_masked.unit == u.m / u.s
+
+
+def test_mask_clumping():
+    """Test properties of clumping function using masked_arrays."""
+    wav = np.arange(1, 101)
+    flux = np.random.random(100) * 10
+    mask = np.asarray(np.floor(2*np.random.random(100)), dtype=bool)
+
+    wav_chunks, flux_chunks = Q.bug_fixed_clumping_method(wav, flux, mask)
+    wav_masked, flux_masked = Q.mask_clumping(wav, flux, mask)
+    # assert len(wav_chunks) == len(wav_masked)
+    # assert len(flux_chunks) == len(flux_masked)
+    for i, __ in enumerate(wav_chunks):
+        assert np.all(wav_chunks[i] == wav_masked[i])
+        assert np.all(flux_chunks[i] == flux_masked[i])
+
+    # All values of clumped mask should be True.
+    mask_clumped, mask2_clumped = Q.mask_clumping(mask, mask, mask)
+    assert len(mask_clumped) == len(mask2_clumped)
+    for i, __ in enumerate(mask_clumped):
+        assert np.all(mask_clumped[i])
+        assert np.all(mask2_clumped[i])
+
+
+def test_manual_clumping():
+    """Test properties of clumping function using masked_arrays."""
+    wav = np.arange(15)
+    flux = np.arange(15, 30)
+    mask = np.array([1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 1, 1, 0])  # , dtype=bool
+    mask_bool = np.array([1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 1, 1, 0], dtype=bool)
+
+    wav_chunks, flux_chunks = Q.bug_fixed_clumping_method(wav, flux, mask)
+    wav_masked, flux_masked = Q.mask_clumping(wav, flux, mask)
+    wav_masked_bool, flux_masked_bool = Q.mask_clumping(wav, flux, mask_bool)
+
+    expected_wav = [np.arange(0, 4), np.arange(7, 10), np.arange(11, 14)]
+    expected_flux = [np.arange(15, 19), np.arange(22, 25), np.arange(26, 29)]
+    for i, chunk in enumerate(wav_chunks):
+        assert np.all(wav_chunks[i] == expected_wav[i])
+        assert np.all(flux_chunks[i] == expected_flux[i])
+        assert np.all(wav_masked[i] == expected_wav[i])
+        assert np.all(flux_masked[i] == expected_flux[i])
+        assert np.all(wav_masked_bool[i] == expected_wav[i])
+        assert np.all(flux_masked_bool[i] == expected_flux[i])
+
+    assert len(wav_chunks) == len(wav_masked)
+    assert len(flux_chunks) == len(flux_masked)
+    assert len(expected_wav) == len(wav_masked)
+    assert len(expected_flux) == len(flux_masked)
+
+    # All values of clumped mask should be True.
+    mask_clumped, mask2_clumped = Q.mask_clumping(mask, mask, mask)
+    assert len(mask_clumped) == len(mask2_clumped)
+    for i, __ in enumerate(mask_clumped):
+        assert np.all(mask_clumped[i])
+        assert np.all(mask2_clumped[i])
+
+
+def test_bugs_in_old_clumping_method():
+    """ Test that it actually works on small tests"""
+    val = np.arange(10)
+
+    # Define masks and expected results from val
+    mask1 = np.ones(10, dtype=bool)
+    expected1 = [val]
+    mask2 = np.array([1, 1, 1, 0, 1, 1, 0, 0, 0, 1], dtype=bool)
+    expected2 = [np.arange(3), np.arange(4, 6), np.array([9])]
+
+    # Failling examples with bugged code
+    mask3 = np.zeros(10, dtype=bool)
+    expected3 = []
+    unexpected3 = [val]
+    mask4 = np.array([0, 1, 0, 0, 0, 1, 1, 1, 1, 0], dtype=bool)
+    expected4 = [np.array([1]), np.arange(5, 9)]
+    unexpected4 = [np.arange(1), np.arange(2, 5), np.array([9])]
+
+    x1, y1 = Q.bug_fixed_clumping_method(val, val, mask1)
+    x1_bugged, y1_bugged = Q.bugged_clumping_method(val, val, mask1)   # This will work
+    for i, __ in enumerate(x1):
+        assert np.all(x1[i] == y1[i])
+        assert np.all(x1[i] == x1_bugged[i])
+        assert np.all(y1[i] == y1_bugged[i])
+        assert np.all(x1[i] == expected1[i])
+
+    x2, y2 = Q.bug_fixed_clumping_method(val, val, mask2)
+    x2_bugged, y2_bugged = Q.bugged_clumping_method(val, val, mask2)  # This will work
+    for i, __ in enumerate(x2):
+        assert np.all(x2[i] == y2[i])
+        assert np.all(x2[i] == x2_bugged[i])
+        assert np.all(y2[i] == y2_bugged[i])
+        assert np.all(x2[i] == expected2[i])
+
+    # Failing examples where mask starts with 0.
+    x3, y3 = Q.bug_fixed_clumping_method(val, val, mask3)
+    x3_bugged, y3_bugged = Q.bugged_clumping_method(val, val, mask3)  # This will fail
+    for i, __ in x3:
+        assert np.all(x3[i] == y3[i])
+        assert np.all(x3_bugged[i] == y3_bugged[i])
+        assert not np.all(x3[i] == x3_bugged[i])
+        assert not np.all(y3[i] == y3_bugged[i])
+        assert np.all(x3[i] == expected3[i])
+        assert not np.all(x3_bugged[i] == expected3[i])
+        assert np.all(x3_bugged[i] == unexpected3[i])
+
+    x4, y4 = Q.bug_fixed_clumping_method(val, val, mask4)
+    x4_bugged, y4_bugged = Q.bugged_clumping_method(val, val, mask4)  # This will fail
+    for i, __ in enumerate(x4):
+        assert np.all(x4[i] == y4[i])
+        assert np.all(x4_bugged[i] == y4_bugged[i])
+        assert not np.all(x4[i] == x4_bugged[i])
+        assert not np.all(y4[i] == y4_bugged[i])
+        assert np.all(x4[i] == expected4[i])
+        assert not np.all(x4_bugged[i] == expected4[i])
+        assert np.all(x4_bugged[i] == unexpected4[i])


### PR DESCRIPTION
Implement np.ma.clump_unmasked for clump RVprecision calculation. 

Many tests of RV precison and clumping which revealed the the bug #26.
 Include warning about possibly error in published results from bug, if situation is encountered again.