### PR TITLE
Remove anaconda from CI

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -3,42 +3,37 @@ python:
     - 3.6
     - 3.7
 
-cache:
-  directories:
-    - $HOME/.cache/pip
-
-install:
-  # Install eniric requirements
-  - travis_retry pip install -r requirements.txt
-  - travis_retry pip install -r requirements_dev.txt
-
-  # Install Starfish
-  - cd $HOME
-  - travis_retry git clone https://github.com/iancze/Starfish.git
-  - cd Starfish
-  - travis_retry pip install -r requirements.txt
-  - python setup.py build_ext --inplace
-  - python setup.py develop
-
-  # Now install eniric
-  - cd $SHIPPABLE_BUILD_DIR
-  - python setup.py install
-
-  # Setup config and make data
-  # This is not the best place to put this but pre_ci didn't work.
-  - mv tests/config.yaml config.yaml
-  # Generate data
-  - make_test_data.py
-  # Prepare atmosphere models
-  - make atmos
-
 build:
-  # pre_ci:
-  #   - mv tests/config.yaml config.yaml
-  #   # Generate data
-  #   - python eniric_scripts/make_test_data.py
+  cache: true
+
+  cache_dir_list:
+      - $HOME/.cache/pip
 
   ci:
+    # Install eniric requirements
+    - travis_retry pip install -r requirements.txt
+    - travis_retry pip install -r requirements_dev.txt
+
+    # Install Starfish
+    - cd $HOME
+    - travis_retry git clone https://github.com/iancze/Starfish.git
+    - cd Starfish
+    - travis_retry pip install -r requirements.txt
+    - python setup.py build_ext --inplace
+    - python setup.py develop
+
+    # Now install eniric
+    - cd $SHIPPABLE_BUILD_DIR
+    - python setup.py install
+
+    # Setup config and make test data
+    # This is not the best place to put this but pre_ci didn't work.
+    - mv tests/config.yaml config.yaml
+    # Generate data
+    - make_test_data.py
+    # Prepare atmosphere models
+    - make atmos
+
     # Create folders for test and code coverage
     - mkdir -p shippable/testresults
     - mkdir -p shippable/codecoverage
@@ -46,7 +41,6 @@ build:
     # Run test and code coverage and output results to the right folder
     - pytest --junitxml=shippable/testresults/nosetests.xml
     - pytest --cov=. --cov-report=xml:shippable/codecoverage/coverage.xml --durations=10
-    # - pytest --cov=. --cov-report term-missing
 
-after_success:
-  - coverage xml -i
+  on_success:
+    - coverage xml -i

--- a/.shippable.yml
+++ b/.shippable.yml
@@ -27,7 +27,7 @@ build:
     - python setup.py install
 
     # Setup config and make test data
-    # This is not the best place to put this but pre_ci didn't work.
+    - export MPLBACKEND="AGG"  # Non-interactive
     - mv tests/config.yaml config.yaml
     # Generate data
     - make_test_data.py

--- a/.shippable.yml
+++ b/.shippable.yml
@@ -3,29 +3,11 @@ python:
     - 3.6
     - 3.7
 
-before_install:
-  # http://conda.pydata.org/docs/travis.html
-  - travis_retry sudo apt-get update
-  - travis_retry wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda config --add channels conda-forge
-  - conda update -q conda
-  - conda info -a
-
 cache:
   directories:
     - $HOME/.cache/pip
 
 install:
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
-  - source activate test-environment
-
-  # Install heavy science packages
-  - travis_retry conda install --yes astropy cython emcee h5py matplotlib scikit-learn scipy
-
   # Install eniric requirements
   - travis_retry pip install -r requirements.txt
   - travis_retry pip install -r requirements_dev.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ install:
   - python setup.py install
 
 before_script:
+  - export MPLBACKEND="AGG"  # Non-interactive
   - mv tests/config.yaml config.yaml
 
   # Generate data

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,28 +5,11 @@ python:
     - 3.6
     - 3.7
 
-before_install:
-  # http://conda.pydata.org/docs/travis.html
-  - travis_retry wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda config --add channels conda-forge
-  - conda update -q conda
-  - conda info -a
-
 cache:
   directories:
     - $HOME/.cache/pip
 
 install:
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
-  - source activate test-environment
-
-  # Install heavy science packages
-  - travis_retry conda install --yes astropy cython emcee h5py matplotlib scikit-learn scipy
-
   # Install eniric requirements
   - travis_retry pip install -r requirements.txt
   - travis_retry pip install -r requirements_dev.txt

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,4 +7,3 @@ pre-commit==1.10.5
 pytest==3.7.2
 pytest-cov==2.5.1
 python-coveralls==2.9.1
-tkinter

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,3 +7,4 @@ pre-commit==1.10.5
 pytest==3.7.2
 pytest-cov==2.5.1
 python-coveralls==2.9.1
+tkinter


### PR DESCRIPTION
Adjusts  .travis.yml and .shippable.yml files

Conda install was slowing down the build

Resolves any package inconsistency between conda and pip.

Have added a matplotlib non-interactive backend for CI.