### PR TITLE
Allow multiprocess pool passed to convolution

### DIFF
--- a/eniric/broaden.py
+++ b/eniric/broaden.py
@@ -115,11 +115,8 @@ def rotational_convolution(
         if num_procs is None:
             num_procs = mprocess.cpu_count() - 1
 
-        mproc_pool = mprocess.Pool(processes=num_procs)
-
-        convolved_flux = np.array(mproc_pool.map(element_rot_convolution, tqdm_wav))
-
-        mproc_pool.close()
+        with mprocess.Pool(processes=num_procs) as mproc_pool:
+            convolved_flux = np.array(mproc_pool.map(element_rot_convolution, tqdm_wav))
 
     else:  # num_procs == 0  or num_procs == 1
         convolved_flux = np.empty_like(wavelength)  # Memory assignment
@@ -214,10 +211,8 @@ def resolution_convolution(
         if num_procs is None:
             num_procs = mprocess.cpu_count() - 1
 
-        mproc_pool = mprocess.Pool(processes=num_procs)
-
-        convolved_flux = np.array(mproc_pool.map(element_res_convolution, tqdm_wav))
-        mproc_pool.close()
+        with mprocess.Pool(processes=num_procs) as mproc_pool:
+            convolved_flux = np.array(mproc_pool.map(element_res_convolution, tqdm_wav))
 
     else:  # num_procs == 0 or num_procs == 1
         convolved_flux = np.empty_like(wavelength)  # Memory assignment

--- a/eniric/broaden.py
+++ b/eniric/broaden.py
@@ -15,6 +15,7 @@ from astropy.constants import c
 from joblib import Memory
 from numpy.core.multiarray import ndarray
 from tqdm import tqdm
+from multiprocess import pool
 
 import eniric
 from eniric.utilities import band_selector, mask_between, wav_selector
@@ -35,7 +36,7 @@ def rotational_convolution(
     *,
     epsilon: float = 0.6,
     normalize: bool = True,
-    num_procs: Optional[Union[int, mprocess.pool.Pool]] = None,
+    num_procs: Optional[Union[int, pool.Pool]] = None,
     verbose: bool = True,
 ) -> ndarray:
     """Perform Rotational convolution.
@@ -152,7 +153,7 @@ def resolution_convolution(
     *,
     fwhm_lim: float = 5.0,
     normalize: bool = True,
-    num_procs: Optional[Union[int, mprocess.pool.Pool]] = None,
+    num_procs: Optional[Union[int, pool.Pool]] = None,
     verbose: bool = True,
 ) -> ndarray:
     """Perform Resolution convolution.

--- a/eniric/broaden.py
+++ b/eniric/broaden.py
@@ -115,11 +115,11 @@ def rotational_convolution(
 
     tqdm_wav = tqdm(wavelength, disable=not verbose)
 
+    if num_procs is None:
+        num_procs = num_procs_minus_1
+
     if isinstance(num_procs, int):
         if (num_procs != 0) or (num_procs != 1):
-            if num_procs is None:
-                num_procs = num_procs_minus_1
-
             with mprocess.Pool(processes=num_procs) as mproc_pool:
                 convolved_flux = np.array(
                     mproc_pool.map(element_rot_convolution, tqdm_wav)
@@ -226,11 +226,11 @@ def resolution_convolution(
 
     tqdm_wav = tqdm(wavelength, disable=not verbose)
 
+    if num_procs is None:
+        num_procs = num_procs_minus_1
+
     if isinstance(num_procs, int):
         if (num_procs != 0) or (num_procs != 1):
-            if num_procs is None:
-                num_procs = num_procs_minus_1
-
             with mprocess.Pool(processes=num_procs) as mproc_pool:
                 convolved_flux = np.array(
                     mproc_pool.map(element_res_convolution, tqdm_wav)

--- a/eniric/broaden.py
+++ b/eniric/broaden.py
@@ -117,7 +117,6 @@ def rotational_convolution(
 
     if isinstance(num_procs, int):
         if (num_procs != 0) or (num_procs != 1):
-            print(type(num_procs), num_procs)
             if num_procs is None:
                 num_procs = num_procs_minus_1
 

--- a/eniric_scripts/phoenix_precision.py
+++ b/eniric_scripts/phoenix_precision.py
@@ -429,6 +429,7 @@ if __name__ == "__main__":
             "fwhm_lim": 5.0,
             "num_procs": mproc_pool,
             "normalize": normalize,
+            "verbose": args.verbose,
         }
         mproc_pool_flag = True
     except:
@@ -437,6 +438,7 @@ if __name__ == "__main__":
             "fwhm_lim": 5.0,
             "num_procs": num_procs,
             "normalize": normalize,
+            "verbose": args.verbose,
         }
         mproc_pool_flag = False
     snr = args.snr

--- a/eniric_scripts/phoenix_precision.py
+++ b/eniric_scripts/phoenix_precision.py
@@ -156,13 +156,22 @@ def do_analysis(
     Parameters
     ----------
     star_param:
+        Stellar parameters [temp, logg, feh, alpha] for phoenix model libraries.
     vsini: float
+       Stellar equatorial rotation.
     R: float
-    band: str 
+        Instrumental resolution.
+    band: str
+        Spectral band.
     sampling: float (default=False)
+        Per pixel sampling (after convolutions)
     conv_kwargs: Dict (default=None)
+        Arguments specific for the convolutions,
+        'epsilon', 'fwhm_lim', 'num_procs', 'normalize', 'verbose'.
     snr: float (default=100)
+        SNR normalization level. SNR per pixel and the center of the ref_band.
     ref_band: str (default="J")
+        Reference band for SNR normalization.
     rv: float
         Radial velocity in km/s (default = 0.0).
     air: bool

--- a/eniric_scripts/phoenix_precision.py
+++ b/eniric_scripts/phoenix_precision.py
@@ -1,11 +1,11 @@
 import argparse
 import itertools
 import os
-from os.path import join
 from typing import List, Tuple
 
-import multiprocess as mprocess
+
 import numpy as np
+import multiprocess as mprocess
 from astropy import units as u
 from astropy.units import Quantity
 from numpy import ndarray
@@ -24,7 +24,7 @@ from eniric.utilities import (
     load_btsettl_spectrum,
 )
 
-num_procs_minus_1 = mprocess.cpu_count() - 1
+num_procs_minus_1 = os.cpu_count() - 1
 
 ref_choices = ["SELF"]
 ref_choices.extend(eniric.bands["all"])

--- a/eniric_scripts/phoenix_precision.py
+++ b/eniric_scripts/phoenix_precision.py
@@ -423,7 +423,7 @@ if __name__ == "__main__":
 
     try:
         # Initalize a multiprocessor pool to pass to each convolution.
-        mproc_pool = mprocess.Pool(processors=num_procs)
+        mproc_pool = mprocess.Pool(processors=num_procs, maxtasksperchild=500000)  # Refresh worker after 1/2 million pixels processed each.
         conv_kwargs = {
             "epsilon": 0.6,
             "fwhm_lim": 5.0,

--- a/eniric_scripts/ps_download_eniric_data.ps1
+++ b/eniric_scripts/ps_download_eniric_data.ps1
@@ -46,7 +46,7 @@ python ..\..\eniric_scripts\untar_here.py ".\obsolete.tar.gz"
 del "obsolete.tar.gz"
 
 # Phoenix-raw data  and BT-settl raw data
-wget "https://www.dropbox.com/s/raw/skg8zwi7vnxgesj/data_raw.tar.gz" -UseBasicParsing -OutFile "phoenix-raw.tar.gz"
+wget "https://www.dropbox.com/s/raw/skg8zwi7vnxgesj/data_raw.tar.gz" -UseBasicParsing -OutFile "data_raw.tar.gz"
 dir
 python ..\..\eniric_scripts\untar_here.py ".\data_raw.tar.gz"
 del "data_raw.tar.gz"

--- a/tests/test_broadening.py
+++ b/tests/test_broadening.py
@@ -1,8 +1,15 @@
 import numpy as np
 import pytest
 from hypothesis import given, settings, strategies as st
+from multiprocess import Pool
 
-from eniric.broaden import rotation_kernel, unitary_gaussian
+from eniric.broaden import (
+    convolution,
+    resolution_convolution,
+    rotational_convolution,
+    rotation_kernel,
+    unitary_gaussian,
+)
 
 
 @settings(max_examples=100)
@@ -64,3 +71,76 @@ def test_unitary_gaussian_type_errors():
         unitary_gaussian(range(-10, 10), "center", fwhm)
     with pytest.raises(TypeError):
         unitary_gaussian(1, "center", fwhm)
+
+
+@pytest.mark.parametrize("num_proc", [1, 2])
+def test_convolution_can_accept_int(num_proc):
+    n = 20
+    x = np.linspace(2.0, 2.3, n)
+    y = np.random.randn(n)
+    convolution(x, y, vsini=1, R=10000, band="K", num_procs=num_proc)
+
+
+@pytest.mark.parametrize("num_proc", [1, 2])
+def test_rot_convolution_can_accept_int(num_proc):
+    n = 20
+    x = np.linspace(2.0, 2.3, n)
+    y = np.random.randn(n)
+    rotational_convolution(x, x, y, vsini=1, num_procs=num_proc)
+
+
+@pytest.mark.parametrize("num_proc", [1, 2])
+def test_res_convolution_can_accept_int(num_proc):
+    n = 20
+    x = np.linspace(2.0, 2.3, n)
+    y = np.random.randn(n)
+    resolution_convolution(x, x, y, R=10000, num_procs=num_proc)
+
+
+@pytest.mark.parametrize("num_proc", [1, 2])
+def test_convolution_can_accept_worker_pool(num_proc):
+    n = 20
+    x = np.linspace(2.0, 2.3, n)
+    y = np.random.randn(n)
+    with Pool(num_proc) as mproc:
+        convolution(x, y, vsini=1, R=10000, band="K", num_procs=mproc, verbose=False)
+
+
+@pytest.mark.parametrize("num_proc", [1, 2])
+def test_rot_convolution_can_accept_worker_pool(num_proc):
+    n = 20
+    x = np.linspace(2.0, 2.3, n)
+    y = np.random.randn(n)
+    with Pool(num_proc) as mproc:
+        rotational_convolution(x, x, y, vsini=1, num_procs=mproc, verbose=False)
+
+
+@pytest.mark.parametrize("num_proc", [1, 2])
+def test_res_convolution_can_accept_worker_pool(num_proc):
+    n = 20
+    x = np.linspace(2.0, 2.3, n)
+    y = np.random.randn(n)
+    with Pool(num_proc) as mproc:
+        resolution_convolution(x, x, y, R=10000, num_procs=mproc, verbose=False)
+
+
+@pytest.mark.parametrize("num_proc", [3.14, "str"])
+def test_rot_convolution_with_bad_num_proc(num_proc):
+    n = 20
+    x = np.linspace(2.0, 2.3, n)
+    y = np.random.randn(n)
+    with pytest.raises(
+        TypeError, message="num_proc must be an int or a multiprocess Pool"
+    ):
+        rotational_convolution(x, x, y, vsini=1, num_procs=num_proc, verbose=False)
+
+
+@pytest.mark.parametrize("num_proc", [3.14, "str"])
+def test_res_convolution_with_bad_num_proc(num_proc):
+    n = 20
+    x = np.linspace(2.0, 2.3, n)
+    y = np.random.randn(n)
+    with pytest.raises(
+        TypeError, message="num_proc must be an int or a multiprocess Pool"
+    ):
+        resolution_convolution(x, x, y, R=10000, num_procs=num_proc, verbose=False)

--- a/tests/test_broadening.py
+++ b/tests/test_broadening.py
@@ -78,7 +78,7 @@ def test_convolution_can_accept_int(num_proc):
     n = 20
     x = np.linspace(2.0, 2.3, n)
     y = np.random.randn(n)
-    convolution(x, y, vsini=1, R=10000, band="K", num_procs=num_proc)
+    convolution(x, y, vsini=1, R=100000, band="K", num_procs=num_proc)
 
 
 @pytest.mark.parametrize("num_proc", [1, 2])
@@ -94,7 +94,7 @@ def test_res_convolution_can_accept_int(num_proc):
     n = 20
     x = np.linspace(2.0, 2.3, n)
     y = np.random.randn(n)
-    resolution_convolution(x, x, y, R=10000, num_procs=num_proc)
+    resolution_convolution(x, x, y, R=100000, num_procs=num_proc)
 
 
 @pytest.mark.parametrize("num_proc", [1, 2])
@@ -103,7 +103,7 @@ def test_convolution_can_accept_worker_pool(num_proc):
     x = np.linspace(2.0, 2.3, n)
     y = np.random.randn(n)
     with Pool(num_proc) as mproc:
-        convolution(x, y, vsini=1, R=10000, band="K", num_procs=mproc, verbose=False)
+        convolution(x, y, vsini=1, R=100000, band="K", num_procs=mproc, verbose=False)
 
 
 @pytest.mark.parametrize("num_proc", [1, 2])
@@ -121,7 +121,7 @@ def test_res_convolution_can_accept_worker_pool(num_proc):
     x = np.linspace(2.0, 2.3, n)
     y = np.random.randn(n)
     with Pool(num_proc) as mproc:
-        resolution_convolution(x, x, y, R=10000, num_procs=mproc, verbose=False)
+        resolution_convolution(x, x, y, R=100000, num_procs=mproc, verbose=False)
 
 
 @pytest.mark.parametrize("num_proc", [3.14, "str"])
@@ -143,4 +143,25 @@ def test_res_convolution_with_bad_num_proc(num_proc):
     with pytest.raises(
         TypeError, message="num_proc must be an int or a multiprocess Pool"
     ):
-        resolution_convolution(x, x, y, R=10000, num_procs=num_proc, verbose=False)
+        resolution_convolution(x, x, y, R=100000, num_procs=num_proc, verbose=False)
+
+
+def test_convolution_can_accept_None():
+    n = 20
+    x = np.linspace(2.0, 2.3, n)
+    y = np.random.randn(n)
+    convolution(x, y, vsini=1, R=100000, band="K", num_procs=None)
+
+
+def test_rot_convolution_can_accept_None():
+    n = 20
+    x = np.linspace(2.0, 2.3, n)
+    y = np.random.randn(n)
+    rotational_convolution(x, x, y, vsini=1, num_procs=None)
+
+
+def test_res_convolution_can_accept_None():
+    n = 20
+    x = np.linspace(2.0, 2.3, n)
+    y = np.random.randn(n)
+    resolution_convolution(x, x, y, R=100000, num_procs=None)


### PR DESCRIPTION
Utilize this in phoenix_precision.py.

This avoids opening and closing the pool of workers for each iteration.

Add some more tests of convolutions.