### PR TITLE
Avoid updated pip in CI servers to avoid pip 517 editable issue.

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -12,7 +12,7 @@ build:
       - $HOME/data
 
   ci:
-    - pip install --upgrade pip<19.1
+    # - pip install --upgrade pip
     # Install eniric requirements
     - travis_retry pip install -r requirements_dev.txt
     - travis_retry pip install -r requirements.txt

--- a/.shippable.yml
+++ b/.shippable.yml
@@ -12,7 +12,7 @@ build:
       - $HOME/data
 
   ci:
-    - pip install --upgrade pip
+    - pip install --upgrade pip<19.1
     # Install eniric requirements
     - travis_retry pip install -r requirements_dev.txt
     - travis_retry pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
     - $HOME/data
 
 install:
-  - pip install --upgrade pip
+  - pip install --upgrade pip<19.1
   # Install eniric requirements
   - travis_retry pip install -r requirements_dev.txt
   - travis_retry pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
     - $HOME/data
 
 install:
-  - pip install --upgrade pip<19.1
+  #  - pip install --upgrade pip
   # Install eniric requirements
   - travis_retry pip install -r requirements_dev.txt
   - travis_retry pip install -r requirements.txt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ cache:
 
 install:
   - SET PATH=%PYTHON%;%PYTHON%\Scripts\;%path%
-  - "%PYTHON%\\python.exe -m pip install --upgrade pip<19.1"
+  # - "%PYTHON%\\python.exe -m pip install --upgrade pip"
   # We need wheel installed to build wheels
   - "%PYTHON%\\python.exe -m pip install wheel"
   -

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ cache:
 
 install:
   - SET PATH=%PYTHON%;%PYTHON%\Scripts\;%path%
-  - "%PYTHON%\\python.exe -m pip install --upgrade pip"
+  - "%PYTHON%\\python.exe -m pip install --upgrade pip<19.1"
   # We need wheel installed to build wheels
   - "%PYTHON%\\python.exe -m pip install wheel"
   -

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ config = {
             "codeclimate-test-reporter>=0.2.3",
             "python-coveralls>=2.9.1",
         ],
-    },  # $ pip install -e .[dev,test, docs]
+    },  # $ pip install -e .[dev,test, docs] --no-use-pep517
     "packages": find_packages(),
     "scripts": [
         "scripts/phoenix_precision.py",


### PR DESCRIPTION
Avoids the issue with pip 19.1.

Will resurface when pip on the CI builds is upgraded. Hopefully, a better fix will be available then.